### PR TITLE
feat: SEO — sitemap, robots.txt, OG metadata, JSON-LD, icon

### DIFF
--- a/app/[locale]/(store)/products/[slug]/page.tsx
+++ b/app/[locale]/(store)/products/[slug]/page.tsx
@@ -17,8 +17,16 @@ interface Props {
   params: Promise<{ locale: Locale; slug: string }>;
 }
 
+const OG_LOCALE: Record<string, string> = {
+  en: "en_US",
+  de: "de_DE",
+  fr: "fr_FR",
+  it: "it_IT",
+  pt: "pt_PT",
+};
+
 export async function generateMetadata({ params }: Props) {
-  const { slug } = await params;
+  const { locale, slug } = await params;
   const id = getProductIdFromSlug(slug);
   if (!id) return {};
 
@@ -26,22 +34,40 @@ export async function generateMetadata({ params }: Props) {
     const detail = await getCachedProduct(id);
     if (!detail) return {};
     const { sync_product } = detail;
-    const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
+    const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "https://www.onlydevs.shop";
+    const canonical = `${appUrl}/${locale}/products/${slug}`;
 
-    // Build hreflang alternates for all 5 locales
-    const alternates = {
-      languages: Object.fromEntries(
-        routing.locales.map((l) => [
-          l,
-          `${appUrl}/${l}/products/${slug}`,
-        ])
-      ),
-    };
+    const rawDesc = `Buy ${sync_product.name} at OnlyDevs — premium developer merch shipped across Switzerland and Europe.`;
+    const description = rawDesc.length > 160 ? rawDesc.slice(0, 157) + "…" : rawDesc;
+
+    const images = sync_product.thumbnail_url
+      ? [{ url: sync_product.thumbnail_url, width: 800, height: 800, alt: sync_product.name }]
+      : [];
 
     return {
       title: sync_product.name,
-      description: `Buy ${sync_product.name} at OnlyDevs — merch for developers.`,
-      alternates,
+      description,
+      alternates: {
+        canonical,
+        languages: Object.fromEntries(
+          routing.locales.map((l) => [l, `${appUrl}/${l}/products/${slug}`])
+        ),
+      },
+      openGraph: {
+        title: `${sync_product.name} | OnlyDevs`,
+        description,
+        url: canonical,
+        siteName: "OnlyDevs",
+        type: "website",
+        locale: OG_LOCALE[locale] ?? "en_US",
+        images,
+      },
+      twitter: {
+        card: "summary_large_image",
+        title: `${sync_product.name} | OnlyDevs`,
+        description,
+        images: images.map((img) => img.url),
+      },
     };
   } catch {
     return {};
@@ -75,7 +101,33 @@ export default async function ProductDetailPage({ params }: Props) {
     sync_variants[0]?.files.find((f) => f.type === "preview")?.preview_url ??
     sync_product.thumbnail_url;
 
+  const lowestVariantPrice = sync_variants[0]?.retail_price;
+  const variantCurrency = sync_variants[0]?.currency ?? "CHF";
+
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Product",
+    name: sync_product.name,
+    image: primaryImage ?? undefined,
+    description: `Developer merch from OnlyDevs — ${sync_product.name}. Ships across Switzerland and Europe.`,
+    brand: { "@type": "Brand", name: "OnlyDevs" },
+    ...(lowestVariantPrice && {
+      offers: {
+        "@type": "Offer",
+        price: lowestVariantPrice,
+        priceCurrency: variantCurrency,
+        availability: "https://schema.org/InStock",
+        seller: { "@type": "Organization", name: "OnlyDevs" },
+      },
+    }),
+  };
+
   return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
     <main className="max-w-5xl mx-auto px-6 py-16">
       <div className="grid grid-cols-1 md:grid-cols-2 gap-12">
         {/* Product image */}
@@ -122,5 +174,6 @@ export default async function ProductDetailPage({ params }: Props) {
         </div>
       </div>
     </main>
+    </>
   );
 }

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -18,15 +18,43 @@ const geistSans = Geist({ variable: "--font-geist-sans", subsets: ["latin"] });
 const geistMono = Geist_Mono({ variable: "--font-geist-mono", subsets: ["latin"] });
 
 export const metadata: Metadata = {
+  metadataBase: new URL(
+    process.env.NEXT_PUBLIC_APP_URL ?? "https://www.onlydevs.shop"
+  ),
   title: {
     default: "OnlyDevs — Merch for Developers",
     template: "%s | OnlyDevs",
   },
   description:
-    "Tech merch and accessories for developers and DevOps engineers. Ships across Switzerland and Europe.",
-  metadataBase: new URL(
-    process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000"
-  ),
+    "Premium apparel and accessories for developers, DevOps engineers and infrastructure nerds. Shipping across Switzerland and Europe.",
+  keywords: [
+    "developer merch",
+    "programmer t-shirts",
+    "devops apparel",
+    "tech accessories",
+    "coding hoodies",
+    "developer gifts",
+    "programmer hoodie",
+    "Switzerland tech merch",
+  ],
+  authors: [{ name: "OnlyDevs" }],
+  robots: { index: true, follow: true },
+  openGraph: {
+    siteName: "OnlyDevs",
+    type: "website",
+    images: [
+      {
+        url: "/onlydevs_logo.png",
+        width: 200,
+        height: 56,
+        alt: "OnlyDevs",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    site: "@onlydevs_shop",
+  },
 };
 
 export function generateStaticParams() {

--- a/app/icon.svg
+++ b/app/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <rect width="32" height="32" rx="6" fill="#0d0d0d"/>
+  <text x="4" y="23" font-family="monospace,sans-serif" font-size="15" font-weight="900" fill="#22c55e">&#62;_</text>
+</svg>

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,13 @@
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      disallow: ["/admin", "/api/", "/account", "/cart", "/checkout"],
+    },
+    sitemap: "https://www.onlydevs.shop/sitemap.xml",
+    host: "https://www.onlydevs.shop",
+  };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,73 @@
+import type { MetadataRoute } from "next";
+import { routing } from "@/lib/i18n/routing";
+import { getCachedProducts } from "@/lib/products";
+
+const BASE = "https://www.onlydevs.shop";
+
+function localeUrls(buildPath: (locale: string) => string): Record<string, string> {
+  return Object.fromEntries(routing.locales.map((l) => [l, `${BASE}${buildPath(l)}`]));
+}
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const products = await getCachedProducts();
+  const now = new Date();
+
+  const staticEntries = routing.locales.flatMap((locale) => [
+    {
+      url: `${BASE}/${locale}`,
+      lastModified: now,
+      changeFrequency: "daily" as const,
+      priority: 1.0,
+      alternates: { languages: localeUrls((l) => `/${l}`) },
+    },
+    {
+      url: `${BASE}/${locale}/products`,
+      lastModified: now,
+      changeFrequency: "daily" as const,
+      priority: 0.9,
+      alternates: { languages: localeUrls((l) => `/${l}/products`) },
+    },
+    {
+      url: `${BASE}/${locale}/about`,
+      lastModified: now,
+      changeFrequency: "monthly" as const,
+      priority: 0.3,
+      alternates: { languages: localeUrls((l) => `/${l}/about`) },
+    },
+    {
+      url: `${BASE}/${locale}/privacy`,
+      lastModified: now,
+      changeFrequency: "monthly" as const,
+      priority: 0.3,
+      alternates: { languages: localeUrls((l) => `/${l}/privacy`) },
+    },
+    {
+      url: `${BASE}/${locale}/terms`,
+      lastModified: now,
+      changeFrequency: "monthly" as const,
+      priority: 0.3,
+      alternates: { languages: localeUrls((l) => `/${l}/terms`) },
+    },
+    {
+      url: `${BASE}/${locale}/cookies`,
+      lastModified: now,
+      changeFrequency: "monthly" as const,
+      priority: 0.3,
+      alternates: { languages: localeUrls((l) => `/${l}/cookies`) },
+    },
+  ]);
+
+  const productEntries = products.flatMap((product) =>
+    routing.locales.map((locale) => ({
+      url: `${BASE}/${locale}/products/${product.slug}`,
+      lastModified: now,
+      changeFrequency: "weekly" as const,
+      priority: 0.8,
+      alternates: {
+        languages: localeUrls((l) => `/${l}/products/${product.slug}`),
+      },
+    }))
+  );
+
+  return [...staticEntries, ...productEntries];
+}


### PR DESCRIPTION
- app/sitemap.ts: dynamic sitemap for all 5 locales × all static pages
  + all products, with hreflang alternates on every entry
- app/robots.ts: allow public, disallow /admin /api /account /cart /checkout
- app/icon.svg: ">_" terminal icon, green on black (#22c55e / #0d0d0d)
- app/[locale]/layout.tsx: add keywords, authors, openGraph defaults, twitter card defaults, robots index/follow, fix metadataBase fallback
- app/[locale]/(store)/products/[slug]/page.tsx: full OG + Twitter card metadata per product (title, description, image, canonical, hreflang, og:locale mapped per locale); Product JSON-LD schema with offers